### PR TITLE
readme: Add a link to gemfic

### DIFF
--- a/README.md
+++ b/README.md
@@ -538,6 +538,7 @@ Gig is used by the following capsules:
 - [paste.gemigrep.com](https://portal.mozz.us/gemini/paste.gemigrep.com) - Paste service
 - [gemini.tunerapp.org](https://portal.mozz.us/gemini/gemini.tunerapp.org) - Internet Radio Stations Directory
 - [pon.ix.tc](https://portal.mozz.us/gemini/pon.ix.tc) - YouTube Proxy and other utiltiies
+- [gemfic.xyz](https://gemfic.xyz) - Fiction hub (Offprint proxy)
 
 If you use Gig, open a PR to add your capsule to this list.
 


### PR DESCRIPTION
Here on GitHub at https://github.com/OffprintStudios/gemfic , on gemini at gemini://gemfic.xyz , and on HTTPS via Kineto at https://gemfic.xyz

Signed-off-by: Alyssa Rosenzweig <alyssa@rosenzweig.io>